### PR TITLE
Sync might not be defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,10 @@ module.exports = function (argv) {
 
   process.on('SIGINT', function () {
     // close gracefully
-    sync.cancel();
+    if (sync) {
+      sync.cancel();
+    }
+    
     db.close(function () {
       skimLocal.close().then(function () {
         process.exit();


### PR DESCRIPTION
Sync isn't defined if npm-local couldn't make a connection. This prevents an error from happening on `ctrl + c`.
