### PR TITLE
(#37) - add shorthand for /pkg/version

### DIFF
--- a/find-version.js
+++ b/find-version.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var semver = require('semver');
+
+// find the first version in the package metadata that satisfies
+// the query version. e.g. if the latest is 1.2.3, then "1", "1.2", and "1.2.3"
+// should all work
+module.exports = function findVersion(meta, version) {
+  if (meta.versions[version]) {
+    return meta.versions[version];
+  }
+  var versions = Object.keys(meta.versions).filter(function (otherVersion) {
+    return semver.satisfies(otherVersion, version);
+  }).sort(function (a, b) {
+    return semver.gt(a, b) ? -1 : 1;
+  });
+  return meta.versions[versions[0]];
+};

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var crypto = require('crypto');
 var https = require('https');
 var http = require('http');
 var url = require('url');
+var findVersion = require('./find-version');
 module.exports = function (argv) {
   var FAT_REMOTE = argv.r;
   var SKIM_REMOTE = argv.R;
@@ -96,7 +97,15 @@ module.exports = function (argv) {
     skimLocal.get(req.params.name).catch(function () {
       return skimRemote.get(req.params.name);
     }).then(function (doc) {
-      res.json(changeTarballs(base, doc).versions[req.params.version]);
+      var packageMetadata = changeTarballs(base, doc);
+      var versionMetadata = findVersion(packageMetadata, req.params.version);
+      if (versionMetadata) {
+        res.json(versionMetadata);
+      } else {
+        res.status(404).json({
+          error: 'version not found: ' + req.params.version
+        });
+      }
     }).catch(function (e) {
       request.get(FAT_REMOTE + req.url).pipe(res);
     });

--- a/package.json
+++ b/package.json
@@ -18,17 +18,18 @@
   "license": "Apache 2",
   "dependencies": {
     "bluebird": "^2.2.2",
+    "colors": "^0.6.2",
+    "compression": "^1.0.10",
     "corser": "^2.0.0",
     "express": "4.6.1",
     "express-pouchdb": "^0.5.1",
+    "level": "^0.18.0",
     "morgan": "^1.2.2",
     "pouchdb": "^3.3.1",
     "request": "^2.39.0",
+    "semver": "^5.0.1",
     "serve-favicon": "^2.0.1",
     "through2": "^0.6.0",
-    "compression": "^1.0.10",
-    "level": "^0.18.0",
-    "colors": "^0.6.2",
     "yargs": "nylen/yargs#fix-camelcase-usage"
   },
   "bin": "./bin.js"


### PR DESCRIPTION
After this fix, the following URLs all work:

* http://127.0.0.1:5080/jsbin/3
* http://127.0.0.1:5080/jsbin/3.11
* http://127.0.0.1:5080/jsbin/3.11.23

And this one throws a 404 error:

* http://127.0.0.1:5080/jsbin/3.11.1337