### PR TITLE
run metadata/tarball fetches in parallel

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,7 @@ module.exports = function (argv) {
   //
   logger.info('\nA simple npm-like UI is available here: http://127.0.0.1:' + port + '/_browse');
   app.use('/_browse', express.static(__dirname + '/www'));
+
   function redirectToSkimdb(req, res) {
     var skimUrl = 'http://localhost:' + pouchPort + '/skimdb';
     var get = request.get(req.originalUrl.replace(/^\/_skimdb/, skimUrl));
@@ -81,6 +82,7 @@ module.exports = function (argv) {
     });
     get.pipe(res);
   }
+
   app.get('/_skimdb', redirectToSkimdb);
   app.get('/_skimdb*', redirectToSkimdb);
 
@@ -126,60 +128,104 @@ module.exports = function (argv) {
     });
   });
   app.get('/tarballs/:name/:version.tgz', function (req, res) {
-    skimLocal.get(req.params.name).catch(function () {
-      return skimRemote.get(req.params.name);
-    }).catch(function () {
+
+    var packageName = req.params.name;
+    var packageVersion = req.params.version;
+    var id = packageName + '-' + packageVersion;
+    var metadata;
+    var localTarball;
+    var localTarballMissed;
+
+    function cacheTarball(getReq) {
+      var buffs = [];
+      getReq.pipe(through(function (chunk, _, next) {
+        buffs.push(chunk);
+        next();
+      }, function (next) {
+        next();
+        var buff = Buffer.concat(buffs);
+        db.put(id, buff, function (err) {
+          if (err) {
+            logger.info(err);
+          } else {
+            logger.cached(packageName, packageVersion);
+          }
+        });
+      }));
+    }
+
+    function onLocalTarballMiss() {
+      logger.miss(packageName, packageVersion);
+      localTarballMissed = true;
+      checkResultsReady();
+    }
+
+    function fetchAndStoreTarball() {
+      var getReq = request.get(metadata.tarball);
+      getReq.on('error', function (err) {
+        logger.info(err);
+        res.status(500).send('you are offline and this package isn\'t cached');
+      });
+      getReq.pipe(res);
+      cacheTarball(getReq, packageName, packageVersion);
+    }
+
+    function checkHashAndReturnTarball() {
+      var hash = crypto.createHash('sha1');
+      hash.update(localTarball);
+      if (metadata.shasum !== hash.digest('hex')) {
+        // happens when we write garbage to disk somehow
+        logger.warn('hashes don\'t match, not returning');
+        onLocalTarballMiss();
+      } else {
+        logger.hit(req.params.name, req.params.version);
+        res.set('content-type', 'application/octet-stream');
+        res.set('content-length', localTarball.length);
+        res.send(localTarball);
+      }
+    }
+
+    function onError(err) {
+      logger.info(err);
       res.status(500).send("you are offline and skimdb isn\'t replicated yet");
-      throw new Error('offline');
+    }
+
+    function checkResultsReady() {
+      if (!metadata || !(localTarball || localTarballMissed)) {
+        return;
+      }
+      if (localTarballMissed) {
+        fetchAndStoreTarball();
+      } else {
+        checkHashAndReturnTarball();
+      }
+    }
+
+    // fetch metadata and tarball in parallel
+
+    skimLocal.get(packageName).catch(function () {
+      return skimRemote.get(packageName);
     }).then(function (doc) {
-      var id = req.params.name + '-' + req.params.version;
       if (fatBase) {
         doc = massageMetadata(fatBase, doc);
       }
-      var dist = doc.versions[req.params.version].dist;
-      db.get(id, {asBuffer: true, valueEncoding: 'binary'}, function (err, resp) {
-        if (!err) {
-          var hash = crypto.createHash('sha1');
-          hash.update(resp);
-          if (dist.shasum !== hash.digest('hex')) {
-            // happens when we write garbage to disk somehow
-            logger.warn('hashes don\'t match, not returning');
-          } else {
-            logger.hit(req.params.name, req.params.version);
-            res.set('content-type', 'application/octet-stream');
-            res.set('content-length', resp.length);
-            return res.send(resp);
-          }
-        }
-        logger.miss(req.params.name, req.params.version);
-        var buffs = [];
-        var get = request.get(dist.tarball);
-        get.on('error', function (err) {
-          logger.info(err);
-          res.status(500).send('you are offline and this package isn\'t cached');
-        });
-        get.pipe(res);
-        get.pipe(through(function (chunk, _, next) {
-          buffs.push(chunk);
-          next();
-        }, function (next) {
-          next();
-          var buff = Buffer.concat(buffs);
-          db.put(id, buff, function (err) {
-            logger.cached(req.params.name, req.params.version);
-            if (err) {
-              logger.info(err);
-            }
-          });
-        }));
-      });
-    }).catch(function (err) {
-      logger.info(err);
+      metadata = doc.versions[packageVersion].dist;
+      checkResultsReady();
+    }, onError);
+
+    db.get(id, {asBuffer: true, valueEncoding: 'binary'}, function (err, resp) {
+      if (err) {
+        return onLocalTarballMiss();
+      }
+      localTarball = resp;
+      checkResultsReady();
     });
   });
+
   app.get('/*', function (req, res) {
     res.redirect(FAT_REMOTE + req.originalUrl);
   });
+
   app.put('/:package', function (req, res) {
     var headers = req.headers;
     var hostURL = url.parse(FAT_REMOTE);
@@ -198,6 +244,7 @@ module.exports = function (argv) {
     });
     req.pipe(nreq);
   });
+
   function massageMetadata(base, doc) {
     Object.keys(doc.versions).forEach(function (key) {
       if (!semver.valid(key)) {
@@ -211,6 +258,7 @@ module.exports = function (argv) {
     });
     return doc;
   }
+
   var sync;
   function replicateSkim() {
     skimRemote.info().then(function (info) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -79,7 +79,7 @@ exports.miss = function (pkg, version) {
     version = String(version);
   }
   log('not cached '.grey + pkg.green + ' at version '.grey + version.green +
-    ' downloading.'.grey);
+    ', downloading...'.grey);
 };
 exports.cached = function (pkg, version) {
   if (level < 2) {


### PR DESCRIPTION
Instead of doing one request at a time, do them
both concurrently. Should speed up tarball requests.