### PR TITLE
get rid of /tarballs path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,10 +42,7 @@ module.exports = function (argv) {
   logger.code('\n  $ npm set registry ' + urlBase);
   logger.info('\nTo switch back, you can run: ');
   logger.code('\n  $ npm set registry ' + FAT_REMOTE);
-  var fatBase = false;
-  if (FAT_REMOTE !== 'https://registry.npmjs.org') {
-    fatBase = FAT_REMOTE + '/tarballs';
-  }
+  var fatRemoteIsLocalNpm = FAT_REMOTE !== 'https://registry.npmjs.org';
   var backoff = 1.1;
   var app = express();
   var PouchDB;
@@ -58,7 +55,6 @@ module.exports = function (argv) {
     auto_compaction: true
   });
   var db = level(path.resolve(directory, 'binarydb'));
-  var base = urlBase + '/tarballs';
 
 
   if (loglevel > 1) {
@@ -71,6 +67,7 @@ module.exports = function (argv) {
   // rudimentary UI based on npm-browser
   //
   logger.info('\nA simple npm-like UI is available here: http://127.0.0.1:' + port + '/_browse');
+
   app.use('/_browse', express.static(__dirname + '/www'));
   function redirectToSkimdb(req, res) {
     var skimUrl = 'http://localhost:' + pouchPort + '/skimdb';
@@ -95,24 +92,42 @@ module.exports = function (argv) {
       });
     });
   });
+
+
+  //
+  // utils
+  //
+
+  function getTgzName(name, version) {
+    return name + '/-/' + name + '-' + version + '.tgz';
+  }
+
+  function massageMetadata(doc) {
+    var name = doc.name;
+    var versions = Object.keys(doc.versions);
+    for (var i = 0, len = versions.length; i < len; i++) {
+      var version = versions[i];
+      if (!semver.valid(version)) {
+        // apparently some npm modules like handlebars
+        // have invalid semver ranges, and npm deletes them
+        // on-the-fly
+        delete doc.versions[version];
+      } else {
+        var tgz = urlBase + '/' + getTgzName(name, version);
+        doc.versions[version].dist.tarball = tgz;
+      }
+    }
+    return doc;
+  }
+
   //
   // actual server logic
   //
-  app.get('/:name', function (req, res) {
-    skimLocal.get(req.params.name).catch(function () {
-      return skimRemote.get(req.params.name);
-    }).then(function (doc) {
-      var docs = massageMetadata(base, doc);
-      res.json(docs);
-    }).catch(function () {
-      request.get(FAT_REMOTE + req.url).pipe(res);
-    });
-  });
   app.get('/:name/:version', function (req, res) {
     skimLocal.get(req.params.name).catch(function () {
       return skimRemote.get(req.params.name);
     }).then(function (doc) {
-      var packageMetadata = massageMetadata(base, doc);
+      var packageMetadata = massageMetadata(doc);
       var versionMetadata = findVersion(packageMetadata, req.params.version);
       if (versionMetadata) {
         res.json(versionMetadata);
@@ -125,18 +140,41 @@ module.exports = function (argv) {
       request.get(FAT_REMOTE + req.url).pipe(res);
     });
   });
-  app.get('/tarballs/:name/:version.tgz', function (req, res) {
+  app.get('/:name', function (req, res) {
     skimLocal.get(req.params.name).catch(function () {
       return skimRemote.get(req.params.name);
+    }).then(function (doc) {
+      var modifiedDoc = massageMetadata(doc);
+      res.json(modifiedDoc);
+    }).catch(function () {
+      request.get(FAT_REMOTE + req.url).pipe(res);
+    });
+  });
+  app.get('/:name/-/:nameAndVersion.tgz', function (req, res) {
+
+    var nameAndVersion = req.params.nameAndVersion;
+    var pkgName = req.params.name;
+
+    if (!(nameAndVersion.substring(0, pkgName.length) === pkgName &&
+      nameAndVersion.charAt(pkgName.length) === '-')) {
+      return res.status(400).send('invalid tgz url');
+    }
+
+    var pkgVersion = nameAndVersion.substring(pkgName.length + 1);
+    var id = pkgName + '-' + pkgVersion;
+
+    console.log('pkgName', pkgName, 'pkgVersion', pkgVersion);
+
+    skimLocal.get(pkgName).catch(function () {
+      return skimRemote.get(pkgName);
     }).catch(function () {
       res.status(500).send("you are offline and skimdb isn\'t replicated yet");
       throw new Error('offline');
     }).then(function (doc) {
-      var id = req.params.name + '-' + req.params.version;
-      if (fatBase) {
-        doc = massageMetadata(fatBase, doc);
+      if (fatRemoteIsLocalNpm) {
+        doc = massageMetadata(doc);
       }
-      var dist = doc.versions[req.params.version].dist;
+      var dist = doc.versions[pkgVersion].dist;
       db.get(id, {asBuffer: true, valueEncoding: 'binary'}, function (err, resp) {
         if (!err) {
           var hash = crypto.createHash('sha1');
@@ -145,28 +183,28 @@ module.exports = function (argv) {
             // happens when we write garbage to disk somehow
             logger.warn('hashes don\'t match, not returning');
           } else {
-            logger.hit(req.params.name, req.params.version);
+            logger.hit(pkgName, pkgVersion);
             res.set('content-type', 'application/octet-stream');
             res.set('content-length', resp.length);
             return res.send(resp);
           }
         }
-        logger.miss(req.params.name, req.params.version);
-        var buffs = [];
-        var get = request.get(dist.tarball);
-        get.on('error', function (err) {
+        logger.miss(pkgName, pkgVersion);
+        var getReq = request.get(dist.tarball);
+        getReq.on('error', function (err) {
           logger.info(err);
           res.status(500).send('you are offline and this package isn\'t cached');
         });
-        get.pipe(res);
-        get.pipe(through(function (chunk, _, next) {
+        getReq.pipe(res);
+        var buffs = [];
+        getReq.pipe(through(function (chunk, _, next) {
           buffs.push(chunk);
           next();
         }, function (next) {
           next();
           var buff = Buffer.concat(buffs);
           db.put(id, buff, function (err) {
-            logger.cached(req.params.name, req.params.version);
+            logger.cached(pkgName, pkgVersion);
             if (err) {
               logger.info(err);
             }
@@ -198,19 +236,6 @@ module.exports = function (argv) {
     });
     req.pipe(nreq);
   });
-  function massageMetadata(base, doc) {
-    Object.keys(doc.versions).forEach(function (key) {
-      if (!semver.valid(key)) {
-        // apparently some npm modules like handlebars
-        // have invalid semver ranges, and npm deletes them
-        // on-the-fly
-        delete doc.versions[key];
-      } else {
-        doc.versions[key].dist.tarball = base + '/' + doc.name + '/' + key + '.tgz';
-      }
-    });
-    return doc;
-  }
   var sync;
   function replicateSkim() {
     skimRemote.info().then(function (info) {

--- a/test/test.js
+++ b/test/test.js
@@ -158,6 +158,17 @@ describe('main test suite', function () {
       `package blob-util should exist`);
   });
 
+  it('installs a pkg with a weird version', async () => {
+    await ncp('./test/project3', WORK_DIR);
+    var pkg = 'esprima-fb';
+    var version = '3001.1.0-dev-harmony-fb';
+    await exec(`npm install ${pkg}@${version}`, {cwd: WORK_DIR});
+    var stat = await statAsync(
+      path.resolve(WORK_DIR, 'node_modules', 'esprima-fb'));
+    stat.isDirectory().should.equal(true,
+      `package esprima-fb should exist`);
+  });
+
   it('doesn\'t install a pkg version that doesn\'t exist', async () => {
     await ncp('./test/project3', WORK_DIR);
     try {
@@ -215,10 +226,25 @@ describe('main test suite', function () {
   });
 
   it('fetches a tarball that does not exist, with version', async () => {
+    var pkg = 'fds2089dfsljkljl329dsfkxxzz9';
     var res = await fetch(
-      'http://127.0.0.1:3030/tarballs/fds2089dfsljkljl329dsfkxxzz9/0.0.1.tgz');
+      `http://127.0.0.1:3030/${pkg}/-/${pkg}-0.0.1.tgz`);
     // this is a fudge for an "offline" error
     res.status.should.equal(500);
+  });
+
+  it('fetches a tarball with an invalid url', async () => {
+    var res = await fetch(
+      `http://127.0.0.1:3030/foo/-/bar-0.0.1.tgz`);
+    // this is a fudge for an "offline" error
+    res.status.should.equal(400);
+  });
+
+  it('fetches a tarball with an invalid url 2', async () => {
+    var res = await fetch(
+      `http://127.0.0.1:3030/foo/-/foob0.0.1.tgz`);
+    // this is a fudge for an "offline" error
+    res.status.should.equal(400);
   });
 
   it('does not allows us to publish an existing package', async () => {


### PR DESCRIPTION
If anyone ever publishes an npm module called `tarballs`, this will start breaking. So we should get rid of it now.