### PR TITLE
(#84) - fix detecting true npm fullfatdb

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,6 +120,14 @@ module.exports = function (argv) {
     return res.send(buffer);
   }
 
+  // TODO: this is an error-prone way to check this. We should probably
+  // send an HTTP request to it and check the response to detect local-npm.
+  var fatRemoteIsAnotherLocalNpm =
+    FAT_REMOTE !== 'https://registry.npmjs.org' &&
+    FAT_REMOTE !== 'https://registry.npmjs.org/' &&
+    FAT_REMOTE !== 'http://registry.npmjs.org' &&
+    FAT_REMOTE !== 'http://registry.npmjs.org/';
+
   //
   // actual server logic
   //
@@ -169,7 +177,7 @@ module.exports = function (argv) {
       logger.timeEnd('2: skimLocal.get(' + pkgName + ')');
       // if we're daisy-chaining multiple local-npm's together,
       // then the remote tarball URL has to be swapped on-the-fly
-      if (FAT_REMOTE !== 'https://registry.npmjs.org') {
+      if (fatRemoteIsAnotherLocalNpm) {
         doc = massageMetadata(FAT_REMOTE, doc);
       }
       var dist = doc.versions[pkgVersion].dist;


### PR DESCRIPTION
Currently we have a flaky way of trying to detect that the "remote fatdb" is another local-npm. We should probably try to improve this.