### PR TITLE
Support for subdomains and routing configurability in general

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -1,0 +1,5 @@
+{
+  "port": 8080,
+  "url-base": "http://local-npm.dev/",
+  "directory": "E:\\local-npm"
+}

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -46,6 +46,10 @@ var yargs = require('yargs')
   .alias('c', 'config')
   .version(require('./../package.json').version, 'v')
   .alias('v', 'version')
+  .option('ui-url', {
+       'default': 'http://127.0.0.1:5080/_browse',
+       describe: 'base url for the UI'
+  })
   .example('local-npm -u http://foo.com -p 3000',
     'run on port 3000 and visable at foo.com');
 

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -2,30 +2,46 @@
 
 'use strict';
 var yargs = require('yargs')
-   .boolean('h')
-  .alias('h', 'help')
-  .describe('h', 'this help message')
-  .default('p', 5080)
-  .alias('p', 'port')
-  .describe('p', 'port')
-  .default('P', 16984)
-  .alias('P', 'pouch-port')
-  .describe('P', 'pouchdb-server port')
-  .alias('l', 'log')
-  .describe('l', 'error|warn|info|debug')
-  .default('l', 'info')
-  .default('r', 'https://registry.npmjs.org')
-  .alias('r', 'remote')
-  .describe('r', 'remote fullfatdb')
-  .default('R', 'https://skimdb.npmjs.com/registry')
-  .alias('R', 'remote-skim')
-  .describe('R', 'remote skimdb')
-  .default('u', 'http://127.0.0.1:5080')
-  .alias('u', 'url-base')
-  .describe('u', 'base url it will be hosted on')
-  .default('d', './')
-  .alias('d', 'directory')
-  .describe('directory', 'directory to store data')
+  .option('h', {
+      alias: 'help',
+      type: 'boolean',
+      describe: 'this help message'
+  })
+  .option('p', {
+      'default': 5080,
+      alias: 'port',
+      describe: 'port'
+  })
+  .option('P', {
+      'default': 16984,
+      alias: 'pouch-port',
+      describe: 'pouchdb-server port'
+  })
+  .option('l', {
+      'default': 'info',
+      alias: 'log',
+      describe: 'error|warn|info|debug'
+  })
+  .option('r', {
+      'default': 'https://registry.npmjs.org',
+      alias: 'remote',
+      describe: 'remote fullfatdb'
+  })
+  .option('R', {
+      'default': 'https://skimdb.npmjs.com/registry',
+      alias: 'remote-skim',
+      describe: 'remote skimdb'
+  })
+  .option('u', {
+      'default': 'http://127.0.0.1:5080',
+      alias: 'url-base',
+      describe: 'base url it will be hosted on'
+  })
+  .option('d', {
+      'default': './',
+      alias: 'directory',
+      describe: 'directory to store data'
+  })
   .version(require('./../package.json').version, 'v')
   .alias('v', 'version')
   .example('$0 -u http://foo.com -p 3000',

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -42,15 +42,18 @@ var yargs = require('yargs')
       alias: 'directory',
       describe: 'directory to store data'
   })
+  .config('c')
+  .alias('c', 'config')
   .version(require('./../package.json').version, 'v')
   .alias('v', 'version')
-  .example('$0 -u http://foo.com -p 3000',
+  .example('local-npm -u http://foo.com -p 3000',
     'run on port 3000 and visable at foo.com');
 
 var argv = yargs.argv;
 
 if (argv.h) {
   yargs.showHelp();
+  console.log(argv);
   process.exit(0);
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+var url = require('url');
 var path = require('path');
 var semver = require('semver');
 var request = require('request');
@@ -24,24 +25,31 @@ var pouchServerLite = require('./pouchdb-server-lite');
 
 
 module.exports = function (argv) {
+  // Format arguments
   var FAT_REMOTE = argv.r;
   var SKIM_REMOTE = argv.R;
   var port = argv.p;
   var pouchPort = argv.P;
   var localBase = argv.u;
-  localBase = localBase.replace(/:5080$/, ':' + port); // port is configurable
+  var registryUrl = url.parse(argv.u);
   var loglevel  = argv.l;
+  loglevel = levels(loglevel);
   var directory = path.resolve(argv.d);
   mkdirp.sync(directory);
-  loglevel = levels(loglevel);
+  var uiUrl = url.parse(argv['ui-url']);
+
   var startingTimeout = 1000;
+
+  //
+  // Welcome message
+  //
   logger.silly('\nWelcome!');
   logger.info('To start using local-npm, just run: ');
   logger.code('\n  $ npm set registry ' + localBase);
   logger.info('\nTo switch back, you can run: ');
   logger.code('\n  $ npm set registry ' + FAT_REMOTE);
+
   var backoff = 1.1;
-  var app = express();
   var PouchDB;
 
   PouchDB = pouchServerLite(argv).PouchDB;
@@ -52,6 +60,7 @@ module.exports = function (argv) {
   });
   var db = level(path.resolve(directory, 'binarydb'));
 
+  var app = express();
 
   if (loglevel > 1) {
     app.use(morgan('dev'));
@@ -62,9 +71,17 @@ module.exports = function (argv) {
   //
   // rudimentary UI based on npm-browser
   //
-  logger.info('\nA simple npm-like UI is available here: http://127.0.0.1:' + port + '/_browse');
+  logger.info('\nA simple npm-like UI is available here: http://' + uiUrl.hostname + ':' + uiUrl.port + uiUrl.path);
 
-  app.use('/_browse', express.static(__dirname + '/www'));
+  // TODO: Publish this as it's own module?
+  // Include the hostname in the path so we can match against it.
+  app.use(function (req, res, next) {
+    req.url = req.hostname + req.path
+    next()
+  })
+
+  app.use(uiUrl.hostname + uiUrl.path, express.static(__dirname + '/www'));
+
   function redirectToSkimdb(req, res) {
     var skimUrl = 'http://localhost:' + pouchPort + '/skimdb';
     var get = request.get(req.originalUrl.replace(/^\/_skimdb/, skimUrl));
@@ -74,10 +91,10 @@ module.exports = function (argv) {
     });
     get.pipe(res);
   }
-  app.get('/_skimdb', redirectToSkimdb);
-  app.get('/_skimdb*', redirectToSkimdb);
+  app.get('*/_skimdb', redirectToSkimdb);
+  app.get('*/_skimdb*', redirectToSkimdb);
 
-  app.get('/', function (req, res) {
+  app.get(registryUrl.hostname + '/', function (req, res) {
     Promise.all([skimLocal.info(), getCount()]).then(function (resp) {
 
       res.json({
@@ -136,7 +153,7 @@ module.exports = function (argv) {
   //
   // actual server logic
   //
-  app.get('/:name/:version', function (req, res) {
+  app.get(registryUrl.hostname + '/:name/:version', function (req, res) {
     skimLocal.get(req.params.name).catch(function () {
       return skimRemote.get(req.params.name);
     }).then(function (doc) {
@@ -161,7 +178,7 @@ module.exports = function (argv) {
           .pipe(res);
     });
   });
-  app.get('/:name', function (req, res) {
+  app.get(registryUrl.hostname + '/:name', function (req, res) {
     var name = req.params.name;
     logger.time('1: skimLocal.get(' + name + ')');
     skimLocal.get(name).catch(function () {
@@ -182,7 +199,7 @@ module.exports = function (argv) {
           .pipe(res);
     });
   });
-  app.get('/tarballs/:name/:version.tgz', function (req, res) {
+  app.get(registryUrl.hostname + '/tarballs/:name/:version.tgz', function (req, res) {
 
     var pkgName = req.params.name;
     var pkgVersion = req.params.version;
@@ -242,10 +259,10 @@ module.exports = function (argv) {
       logger.info(err);
     });
   });
-  app.get('/*', function (req, res) {
+  app.get(registryUrl.hostname + '/*', function (req, res) {
     res.redirect(FAT_REMOTE + req.originalUrl);
   });
-  app.put('/*', proxy(FAT_REMOTE));
+  app.put(registryUrl.hostname + '/*', proxy(FAT_REMOTE));
 
   var sync;
   function replicateSkim() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ module.exports = function (argv) {
   //
   // rudimentary UI based on npm-browser
   //
-  logger.info('\nA simple npm-like UI is available here: http://' + uiUrl.hostname + ':' + uiUrl.port + uiUrl.path);
+  logger.info('\nA simple npm-like UI is available here: ' + uiUrl.href);
 
   // TODO: Publish this as it's own module?
   // Include the hostname in the path so we can match against it.

--- a/lib/www/scripts/services/pouch-service.js
+++ b/lib/www/scripts/services/pouch-service.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function PouchService() {
-  var couchUrl = window.location.href.replace(/\/_browse.*$/, '/_skimdb');
+  var couchUrl = window.location.protocol + '//' + window.location.host + '/_skimdb';
   this.pouch = new PouchDB(couchUrl);
 }
 


### PR DESCRIPTION
(This isn't ready to be merged. I'm just opening it now for discussion.)

The Express server has some hard-coded mounting points, such as `/_browse`, `/_skimdb`, and `/_utils`. I wanted to mount the UI at `browse.node-modules.io`, the registry at `registry.node-modules.io`, etc, so I'm adding that ability here. Also, I wanted to be able to specify all these paths and ports in a config file rather than as command line flags, so I'm adding that.

It [appears to work](https://local-npm.node-modules.io/) as I open this pull request, but I'm not satisfied with it. I think I can make it a lot simpler, possibly even splitting the UI, registry, and tarball services in such a way that they could be individually enabled/disabled so you could (for example) run the UI on one node, have the tarballs routed through a CDN, and run the registry on a separate machine and a different port. Something like:

    @node1:~$ local-npm --browse=http://browse.node-modules.io --tarballs=http://cdn.node-modules.io --port=8080
    @node2:~$ local-npm --registry=https://registry.node-modules.io:5858 --port=5858

@zeke Ultimately, splitting the code cleanly into modules by separating concerns will make it easier to do crazy things, like support alternative backends (IPFS?).